### PR TITLE
add `skipCache` Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ ITPExpressRedisCache.route({
 })
 ```
 
+## Application-level middleware
+
+Simply use `app.use` of express to use `ITPExpressRedisCache` as an Application-level middleware.
+
+```javascript
+app.use(ITPExpressRedisCache.route())
+```
+
+## Disable Caching inside the Route
+
+You can disable caching for specific routes by adding `res.skipCache = true` to opt out the route from getting cached.
+
+```javascript
+app.get('/:paramKey', function (req, res) {
+    res.skipCache = (paramKey === 1300);
+    res.send("Hello");
+});
+```
+
+
 ## Supported env variables
 
 - REDIS_HOST

--- a/README.md
+++ b/README.md
@@ -93,12 +93,11 @@ app.use(ITPExpressRedisCache.route())
 You can disable caching for specific routes by adding `res.skipCache = true` to opt out the route from getting cached.
 
 ```javascript
-app.get('/:paramKey', function (req, res) {
-    res.skipCache = (paramKey === 1300);
-    res.send("Hello");
+app.get('/:paramKey', (req, res) => {
+    res.skipCache = paramKey === 1300;
+    res.send('Hello');
 });
 ```
-
 
 ## Supported env variables
 

--- a/lib/ITPExpressRedisCache.js
+++ b/lib/ITPExpressRedisCache.js
@@ -9,7 +9,7 @@ const ITPExpressRedisCache = {};
  */
 ITPExpressRedisCache.route = (routeOptions = {}) => {
   return (req, res, next) => {
-    if (!this.redisClient || !this.connected) {
+    if (res.skipCache || !this.redisClient || !this.connected) {
       next();
       return;
     }


### PR DESCRIPTION
Skip caching if `res.skipCache` is set to `true` in the route.

I am using this library as a middleware rather on a per route basis. sometimes i want to disable the caching for certain routes, or on certain conditions.

Adding `res.skipCache` to the route will opt out the route from getting cached.


## Example
```
const ITPExpressRedisCache = require('itp-express-redis-cache')({
    port: redisPort,
    host: redisHost,
    authPass: null,
    enabled: true,
 });

 app.use(ITPExpressRedisCache.route())

app.get('/:index/:cityId', function (req, res) {
    res.skipCache = (req.cityId === 1300);
});
```