### PR TITLE
switched redis.createClient to object

### DIFF
--- a/lib/ITPExpressRedisCache.js
+++ b/lib/ITPExpressRedisCache.js
@@ -77,7 +77,7 @@ ITPExpressRedisCache.connect = (options = {}) => {
   const host = options.host || process.env.REDIS_HOST || 'localhost';
   const port = options.port || process.env.REDIS_PORT || 6379;
   const authPass = options.authPass || process.env.REDIS_PASS;
-  const db = options.db || process.env.REDIS_DB;
+  const db = options.db || process.env.REDIS_DB || 0;
 
   this.prefix = options.prefix || require('./../package.json').name;
   this.connected = false;

--- a/lib/ITPExpressRedisCache.js
+++ b/lib/ITPExpressRedisCache.js
@@ -76,7 +76,7 @@ ITPExpressRedisCache.connect = (options = {}) => {
   const enabled = options.enabled !== false;
   const host = options.host || process.env.REDIS_HOST || 'localhost';
   const port = options.port || process.env.REDIS_PORT || 6379;
-  const authPass = options.authPass || process.env.REDIS_PASS;
+  const password = options.authPass || process.env.REDIS_PASS;
   const db = options.db || process.env.REDIS_DB || 0;
 
   this.prefix = options.prefix || require('./../package.json').name;
@@ -84,12 +84,12 @@ ITPExpressRedisCache.connect = (options = {}) => {
   this.excludeStatuscodes = Object.prototype.hasOwnProperty.call(options, 'excludeStatuscodes') ? options.excludeStatuscodes : 500;
 
   if (enabled) {
-    this.redisClient = require('redis').createClient(
+    this.redisClient = require('redis').createClient({
       port,
       host,
-      { auth_pass: authPass },
+      password,
       db
-    );
+    });
 
     setEventListeners();
   } else {

--- a/lib/ITPExpressRedisCache.js
+++ b/lib/ITPExpressRedisCache.js
@@ -77,7 +77,7 @@ ITPExpressRedisCache.connect = (options = {}) => {
   const host = options.host || process.env.REDIS_HOST || 'localhost';
   const port = options.port || process.env.REDIS_PORT || 6379;
   const authPass = options.authPass || process.env.REDIS_PASS;
-  const db = options.db || process.env.REDIS_DB || 0;
+  const db = options.db || process.env.REDIS_DB;
 
   this.prefix = options.prefix || require('./../package.json').name;
   this.connected = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itp-express-redis-cache",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A light api route cache system with Redis for Express",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
my addition of `db` wasn't working because i needed to pass in an object, not an array, to `redis.createClient`.